### PR TITLE
String::Multibyte is finicky

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -4,7 +4,7 @@ Password::Policy - Make managing multiple password strength profiles easy
 
 # VERSION
 
-version 0.04
+version 0.05
 
 # UNICODE
 
@@ -15,7 +15,7 @@ If you find a case where Unicode characters don't behave correctly, please let m
 # EXCEPTIONS
 
 This module tries to throw a well defined exception object when it encounters an
-error. Wrapping it in something like [Try::Tiny](https://metacpan.org/pod/Try::Tiny) is highly recommended, so that
+error. Wrapping it in something like [Try::Tiny](https://metacpan.org/pod/Try%3A%3ATiny) is highly recommended, so that
 you can handle errors intelligently.
 
 # EXTENDING
@@ -83,7 +83,7 @@ The two most obvious use cases are:
       password should be made of stronger stuff.
 
 The whole thing is driven by a configuration file, passed in on instantiation. It uses
-[Config::Any](https://metacpan.org/pod/Config::Any) internally, so the config file format can be whatever you would like. The
+[Config::Any](https://metacpan.org/pod/Config%3A%3AAny) internally, so the config file format can be whatever you would like. The
 examples all use YAML, but anything Config::Any understands will work.
 
 Assuming a configuration file looks like this:
@@ -140,6 +140,8 @@ to encrypt, and optionally any arguments you want to pass to the algorithm's mod
 # ACKNOWLEDGEMENTS
 
 The unit tests got a nice round of cleanup from StarLightPL. Thanks!
+
+Pete Houston (openstrike@github) found some weirdness around how unicode string lengths were handled. Thank you!
 
 # AUTHOR
 

--- a/lib/Password/Policy/Rule/Length.pm
+++ b/lib/Password/Policy/Rule/Length.pm
@@ -15,9 +15,16 @@ sub check {
     my $self = shift;
     my $password = $self->prepare(shift);
     my $strmb = String::Multibyte->new('UTF8');
-    my $len = $strmb->length($password);
-    if($len < $self->arg) {
-        Password::Policy::Exception::InsufficientLength->throw;
+    if($strmb->islegal($password)) {
+        my $len = $strmb->length($password);
+        if($len < $self->arg) {
+            Password::Policy::Exception::InsufficientLength->throw;
+        }
+    } else {
+        my $len = length $password;
+        if($len < $self->arg) {
+            Password::Policy::Exception::InsufficientLength->throw;
+        }
     }
     return 1;
 }


### PR DESCRIPTION
[#3]: Make sure String::Multibyte will accept whatever we're passing it. The length method is used as a fallback, which is not perfect, but probably covers for Unicode weirdness. Been a while since I wrangled Unicode in perl, so thinking about this a little more before I do a release.